### PR TITLE
Upgrade to rodio 0.12 from crates.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 * image: Add support for loading Bmp and Jpeg images.
 * **breaking** image, font, audio: Standardize naming convention for asset loading, renaming methods
     to `load`, and taking an explicit format argument where applicable.
-* **breaking** audio: Move rodio dependency to git dependency to support format specific decoding.
-    Required creating `AudioMainThreadState` to store new `rodio::OutputStream` value.
+* **breaking** audio: Upgrade to rodio 0.12. Required creating `AudioMainThreadState` to store new
+    `rodio::OutputStream` value.
 * image, font, audio: Add `load_async` methods to asset types.
 * **breaking** riddle: rename cargo features to be consistent with crate names.
 * audio, riddle: add optional mp3 support behind feature `riddle-mp3`.

--- a/riddle-audio/Cargo.toml
+++ b/riddle-audio/Cargo.toml
@@ -14,7 +14,7 @@ riddle-mp3 = ["rodio/mp3"]
 riddle-common = {path = "../riddle-common"}
 
 futures = "0.3"
-rodio = { version = "0.11", git = "https://github.com/vickles/rodio/", branch="riddle0.2.0", default-features=false, features=["wav", "vorbis"] }
+rodio = { version = "0.12", features=["wav", "vorbis"] }
 thiserror = "1.0"
 
 


### PR DESCRIPTION
Rodio 0.12 includes the patch for format specific parsing methods, so we don't need to use the custom git fork any more.

Related to #23