### PR TITLE
Relax run_with_err bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,6 @@
 * docs: Update pong example to support gamepad input
 * **breaking**: Put internal system methods in to Ext traits, expose underlying types with crate specific Ext traits.
 * input: MacOS scancode normalization
+* riddle: Relax bounds on error type param for `RiddleLib::run_with_err` to allow use with `anyhow::Error`.
 
 ## 0.1.0 - Initial Release

--- a/riddle/src/riddle_lib.rs
+++ b/riddle/src/riddle_lib.rs
@@ -74,7 +74,7 @@ impl RiddleLib {
     /// })
     /// # }
     /// ```
-    pub fn run_with_err<Err: std::error::Error, F>(self, update: F) -> !
+    pub fn run_with_err<Err: std::fmt::Debug, F>(self, update: F) -> !
     where
         F: FnMut(&RiddleContext) -> std::result::Result<(), Err> + 'static,
     {

--- a/riddle/src/state.rs
+++ b/riddle/src/state.rs
@@ -82,7 +82,7 @@ pub(crate) struct MainThreadState {
 
 impl MainThreadState {
     #[inline]
-    pub fn run<Err: std::error::Error, F>(self, state: RiddleState, mut update: F) -> !
+    pub fn run<Err: std::fmt::Debug, F>(self, state: RiddleState, mut update: F) -> !
     where
         F: FnMut(&RiddleContext) -> std::result::Result<(), Err> + 'static,
     {


### PR DESCRIPTION
Bounds on the error type on `RiddleLib::run_with_err` were too strict to allow the function to be used with `anyhow::Error` as the error type, or with any other error type that doesn't implement std::error::Error. This change relaxes the bound to just `: std::fmt::Debug`.